### PR TITLE
ValueParser QUnit tests: Renamed getObject to getConstructor

### DIFF
--- a/js/src/ValueParsers/mw.ext.valueParsers.js
+++ b/js/src/ValueParsers/mw.ext.valueParsers.js
@@ -35,9 +35,9 @@
 	 * Object representing the MediaWiki "ValueParsers" extension.
 	 * @since 0.1
 	 */
-	mw.ext.valueParsers = new ( function MwExtValueView() {
+	mw.ext.valueParsers = new ( function MwExtValueParsers() {
 		/**
-		 * Value parser provider holding all value parsers available in global MediaWiki context.
+		 * Value parser provider containing all value parsers available in global MediaWiki context.
 		 * @since 0.1
 		 *
 		 * @type {valueParsers.ValueParserFactory}

--- a/js/tests/ValueParsers/ValueParser.tests.js
+++ b/js/tests/ValueParsers/ValueParser.tests.js
@@ -1,11 +1,9 @@
 /**
- * @file
- * @ingroup DataValues
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Daniel Werner < danweetz@web.de >
  */
-( function( vp, dv, $, QUnit, undefined ) {
+( function( vp, dv, $, QUnit ) {
 	'use strict';
 
 	vp.tests = {};
@@ -30,34 +28,34 @@
 		getParseArguments: vp.util.abstractMember,
 
 		/**
-		 * Returns the ValueParser object to be tested (ie vp.IntParser).
+		 * Returns the ValueParser constructor to be tested.
 		 *
 		 * @since 0.1
 		 *
-		 * @return vp.ValueParser
+		 * @return {Function}
 		 */
-		getObject: vp.util.abstractMember,
+		getConstructor: vp.util.abstractMember,
 
 		/**
-		 * Returns the dataValue object to be tested (ie dv.StringValue).
+		 * Returns the ValueParser instance to be tested.
 		 *
 		 * @since 0.1
 		 *
 		 * @param {Array} constructorArguments
 		 *
-		 * @return vp.ValueParser
+		 * @return {valueParsers.ValueParser}
 		 */
 		getInstance: function( constructorArguments ) {
 			constructorArguments = constructorArguments || this.getDefaultConstructorArgs();
 
 			var
 				self = this,
-				ValueParserInstance = function( constructorArguments ) {
-					self.getObject().apply( this, constructorArguments );
+				ValueParserConstructor = function( constructorArguments ) {
+					self.getConstructor().apply( this, constructorArguments );
 				};
 
-			ValueParserInstance.prototype = this.getObject().prototype;
-			return new ValueParserInstance( constructorArguments );
+			ValueParserConstructor.prototype = this.getConstructor().prototype;
+			return new ValueParserConstructor( constructorArguments );
 		},
 
 		getDefaultConstructorArgs: function() {
@@ -111,9 +109,6 @@
 						: '';
 
 				var request = parser.parse( parseInput )
-					.always( function() {
-						//QUnit.start();
-					} )
 					.done( function( dataValue ) {
 						// promise resolved, so no error has occured
 						assert.ok( true, 'parsing succeeded' );

--- a/js/tests/ValueParsers/parsers/BoolParser.tests.js
+++ b/js/tests/ValueParsers/parsers/BoolParser.tests.js
@@ -23,9 +23,9 @@
 	vp.tests.BoolParserTest = vp.util.inherit( PARENT, constructor, {
 
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return vp.BoolParser;
 		},
 

--- a/js/tests/ValueParsers/parsers/FloatParser.tests.js
+++ b/js/tests/ValueParsers/parsers/FloatParser.tests.js
@@ -21,9 +21,9 @@
 	vp.tests.FloatParserTest = vp.util.inherit( PARENT, {
 
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return vp.FloatParser;
 		},
 

--- a/js/tests/ValueParsers/parsers/GlobeCoordinateParser.tests.js
+++ b/js/tests/ValueParsers/parsers/GlobeCoordinateParser.tests.js
@@ -22,9 +22,9 @@
 	vp.tests.GlobeCoordinateParserTest = vp.util.inherit( PARENT, {
 
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return vp.GlobeCoordinateParser;
 		},
 

--- a/js/tests/ValueParsers/parsers/IntParser.tests.js
+++ b/js/tests/ValueParsers/parsers/IntParser.tests.js
@@ -23,9 +23,9 @@
 	vp.tests.IntParserTest = vp.util.inherit( PARENT, constructor, {
 
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return vp.IntParser;
 		},
 

--- a/js/tests/ValueParsers/parsers/NullParser.tests.js
+++ b/js/tests/ValueParsers/parsers/NullParser.tests.js
@@ -23,9 +23,9 @@
 	vp.tests.NullParserTest = vp.util.inherit( PARENT, constructor, {
 
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return vp.NullParser;
 		},
 

--- a/js/tests/ValueParsers/parsers/QuantityParser.tests.js
+++ b/js/tests/ValueParsers/parsers/QuantityParser.tests.js
@@ -14,9 +14,9 @@ valueParsers.tests.QuantityParserTest = ( function(
 	var PARENT = ValueParserTest;
 	var QuantityParserTest = inherit( PARENT, {
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return QuantityParser;
 		},
 

--- a/js/tests/ValueParsers/parsers/StringParser.tests.js
+++ b/js/tests/ValueParsers/parsers/StringParser.tests.js
@@ -21,9 +21,9 @@
 	vp.tests.StringParserTest = vp.util.inherit( PARENT, {
 
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return vp.StringParser;
 		},
 

--- a/js/tests/ValueParsers/parsers/TimeParser.tests.js
+++ b/js/tests/ValueParsers/parsers/TimeParser.tests.js
@@ -21,9 +21,9 @@
 	vp.tests.TimeParserTest = vp.util.inherit( PARENT, {
 
 		/**
-		 * @see vp.tests.ValueParserTest.getObject
+		 * @see vp.tests.ValueParserTest.getConstructor
 		 */
-		getObject: function() {
+		getConstructor: function() {
 			return vp.TimeParser;
 		},
 


### PR DESCRIPTION
Change by H. Snater. Ported from https://gerrit.wikimedia.org/r/#/c/102091/
