### PR TITLE
Make ISO time parsing more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ On [Packagist](https://packagist.org/packages/data-values/javascript):
 #### Bugfixes
 
 * Fixed definitions of ResourceLoader test modules.
+* Accept ISO8601-formatted timestamps with zeroes as months and days
 
 ### 0.3.1 (2014-02-03)
 

--- a/lib/time/time.Time.js
+++ b/lib/time/time.Time.js
@@ -252,7 +252,7 @@ time.Time = ( function( time, $ ) {
 	 * @throws {Error} If the input string is invalid.
 	 */
 	Time.newFromIso8601 = function( iso8601String, precision ) {
-		var year, month, day;
+		var year, month, day, timeObj;
 
 		try{
 			year = parseInt(
@@ -260,7 +260,7 @@ time.Time = ( function( time, $ ) {
 				10
 			);
 			month = parseInt(
-				iso8601String.match( /(?:[1-9]|1[012])(?=\-\d+T)/ )[0],
+				iso8601String.match( /(?:0?\d|1[012])(?=\-\d+T)/ )[0],
 				10
 			);
 			day = parseInt(
@@ -271,13 +271,21 @@ time.Time = ( function( time, $ ) {
 			throw new Error( 'Unprocessable iso8601 string given' );
 		}
 
-		return new Time( {
+		timeObj = {
 			year: year,
-			month: month,
-			day: day,
 			precision: precision !== undefined ? precision : Time.PRECISION.DAY,
 			calendarname: Time.CALENDAR.GREGORIAN
-		} );
+		};
+
+		if( month !== 0 ) {
+			timeObj.month = month;
+		}
+
+		if( day !== 0 ) {
+			timeObj.day = day;
+		}
+
+		return new Time( timeObj );
 	};
 
 	/**


### PR DESCRIPTION
Years and months ISOs come from the Wikibase parser with the day portion set
to 00. This is not valid, but well-formatted, and we should be able to read it.
