### PR TITLE
Don't register the TimeParser

### DIFF
--- a/DataValuesJavascript.php
+++ b/DataValuesJavascript.php
@@ -7,7 +7,7 @@ if ( defined( 'DATA_VALUES_JAVASCRIPT_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATA_VALUES_JAVASCRIPT_VERSION', '0.3.2 alpha' );
+define( 'DATA_VALUES_JAVASCRIPT_VERSION', '0.4.0 alpha' );
 
 // Include the composer autoloader if it is present.
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ On [Packagist](https://packagist.org/packages/data-values/javascript):
 
 ## Release notes
 
-### 0.3.2 (dev)
+### 0.4.0 (dev)
+
+#### Breaking changes
+
+* mw.ext.valueParsers does not register valueParsers.TimeParser anymore
+
+### 0.3.2 (???)
 
 #### Bugfixes
 

--- a/src/valueParsers/mw.ext.valueParsers.js
+++ b/src/valueParsers/mw.ext.valueParsers.js
@@ -16,11 +16,6 @@
 		dv.StringValue.TYPE
 	);
 
-	valueParserProvider.registerDataValueParser(
-		vp.TimeParser,
-		dv.TimeValue.TYPE
-	);
-
 	/**
 	 * Object representing the MediaWiki "ValueParsers" extension.
 	 * @since 0.1


### PR DESCRIPTION
Wikibase wants to use its own API-based parsing.

We might consider removing the TimeParsers, too. Also we should consider in which release this change should go (0.3.2 or 0.4.0?). See also [Wikibase change](https://gerrit.wikimedia.org/r/#/c/111464/).
