### PR TITLE
Fix test that did not tested much

### DIFF
--- a/tests/lib/globeCoordinate/globeCoordinate.Formatter.tests.js
+++ b/tests/lib/globeCoordinate/globeCoordinate.Formatter.tests.js
@@ -51,49 +51,23 @@ define( [
 	} );
 
 	QUnit.test( 'precisionText()', function( assert ) {
-		var c,
-			precisions = {
-				1: 1,
-				0.016666666666666666: 1 / 60,
-				2.7777777777777776e-7: 1 / 3600000,
+		var precisions = {
+				1: 'to a degree',
+				0.016666666666666666: 'to an arcminute',
+				2.7777777777777776e-7: 'to 1/1000 of an arcsecond',
 				10: '±10°'
 			},
 			formatter = new Formatter();
 
 		$.each( precisions, function( testPrecision, expected ) {
-			c = new GlobeCoordinate(
-				{ latitude: 1, longitude: 1, precision: testPrecision }
-			);
-
-			var precisionText = Formatter.PRECISIONTEXT( testPrecision );
+			var precisionText = formatter.precisionText( testPrecision );
 
 			// Look up precision text:
-			if( typeof expected === 'number' ) {
-
-				$.each( [ 10, 1, 1 / 60, 1 / 3600000 ], function( i, precision ) {
-					if( '' + precision === testPrecision ) {
-
-						assert.strictEqual(
-							precisionText,
-							formatter.precisionText( c.getPrecision() ),
-							'Precision text for \'' + precision + '\' results in text \''
-								+ precisionText + '\'.'
-						);
-
-						return false;
-					}
-				} );
-
-			} else {
-
-				assert.strictEqual(
-					precisionText,
-					expected,
-					'Precision text for \'' + testPrecision + '\' results in text \'' + expected + '\'.'
-				);
-
-			}
-
+			assert.strictEqual(
+				precisionText,
+				expected,
+				'Precision text for \'' + testPrecision + '\' results in text \'' + expected + '\'.'
+			);
 		} );
 
 	} );


### PR DESCRIPTION
This test barely tested anything.
1. The inner loop was just pointless.
2. Three of the four assertions compared the output from `Formatter.PRECISIONTEXT` with the output from `globeCoordinate.Formatter.prototype.precisionText` which is a single line that calls `Formatter.PRECISIONTEXT`. I really don't think this was intended.

Warning: This conflicts with #40. It may be better to merge #40 first and rebase this.
