### PR TITLE
Display 1 degree as number, not text

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ On [Packagist](https://packagist.org/packages/data-values/javascript):
 
 * Removed the arbitrary list of precisions for globe coordinates
 
+#### Enhancements
+
+* #42 Removed 'to a degree' label, now shown as '±1°'
+
 ### 0.5.1 (2014-06-04)
 
 #### Bugfixes

--- a/lib/globeCoordinate/globeCoordinate.Formatter.js
+++ b/lib/globeCoordinate/globeCoordinate.Formatter.js
@@ -24,7 +24,6 @@ globeCoordinate.Formatter = ( function( globeCoordinate ) {
 		minute: '\'',
 		second: '"',
 		precisionTexts: [
-			{ precision: 1, text: 'to a degree' },
 			{ precision: 1 / 60, text: 'to an arcminute' },
 			{ precision: 1 / 3600, text: 'to an arcsecond' },
 			{ precision: 1 / 36000, text: 'to 1/10 of an arcsecond' },

--- a/tests/lib/globeCoordinate/globeCoordinate.Formatter.tests.js
+++ b/tests/lib/globeCoordinate/globeCoordinate.Formatter.tests.js
@@ -52,7 +52,7 @@ define( [
 
 	QUnit.test( 'precisionText()', function( assert ) {
 		var precisions = {
-				1: 'to a degree',
+				1: '±1°',
 				0.016666666666666666: 'to an arcminute',
 				2.7777777777777776e-7: 'to 1/1000 of an arcsecond',
 				10: '±10°'


### PR DESCRIPTION
There are two types of labels: One half ranges from `±0.000001°` to `±10°`. The other half is based on minutes and seconds and shown as text.

But why is `±0.1°` a number, `±1°` is not a number but `±10°` is a number again? Discussed with @lydiapintscher and decided to remove it. It's not translated anyway.

Note: This is related to https://github.com/wmde/ValueView/issues/60 but can be merged independently.
