### PR TITLE
[WIP] Reimplement removed constructor naming

### DIFF
--- a/lib/util/util.inherit.js
+++ b/lib/util/util.inherit.js
@@ -41,8 +41,6 @@ this.util = this.util || {};
 	 * @throws {Error} if the given name has no characters matching [\w$].
 	 */
 	function createNamedFunction( name, originalFn ) {
-		/* jshint evil: true */
-		/* jshint unused: false */
 		var namedFn;
 		var evilsSeed = originalFn || EMPTY_FN;
 		var fnName = name.replace( /(?:(^\d+)|[^\w$])/ig, '' );
@@ -52,10 +50,13 @@ this.util = this.util || {};
 			throw new Error( 'Bad function name given. At least one word character or $ required.' );
 		}
 
-		eval( 'namedFn = function ' + fnName +
-			'(){ evilsSeed.apply( this, arguments ); }' );
+		// No, none of these functions is superfluous! Before this used to fail with a
+		// "ReferenceError: evilsSeed is not defined" when Shift+reloading in Firefox.
+		// Source: http://stackoverflow.com/a/22880379
+		namedFn = ( new Function( 'return function( fn ) { return function ' + fnName +
+			'() { return fn( this, arguments ); }; };' )() )( Function.apply.bind( evilsSeed ) );
 
-		return namedFn; // value got assigned in eval
+		return namedFn || evilsSeed;
 	}
 
 	/**


### PR DESCRIPTION
This `ReferenceError: evilsSeed is not defined` is driving me crazy. I can always reproduce it by simply shift+reloading a page in my local Wikibase Repo. This is a huge pain when debugging.

**Update:** #45 removes this feature. It should be readded when the PhantomJS bug mentioned below got fixed and the Travis tests pass.
