### PR TITLE
Fix incomplete Time.equals

### DIFF
--- a/lib/time/time.Time.js
+++ b/lib/time/time.Time.js
@@ -232,6 +232,10 @@ time.Time = ( function( time, $ ) {
 		}
 
 		return this.precision() === otherTime.precision()
+			&& this.calendar() === otherTime.calendar()
+			&& this.after() === otherTime.after()
+			&& this.before() === otherTime.before()
+			&& this.utcoffset() === otherTime.utcoffset()
 			&& this.iso8601() === otherTime.iso8601();
 	};
 


### PR DESCRIPTION
Yes, `after`, `before` and `utcoffset` are constants currently. I included them anyway to not run into the same bug again in the near future.

I tried to put the comparisons in an order that's probably most efficient: stuff that's less likely to change to the back, most complicated stuff last.

[Bug: 65847](https://bugzilla.wikimedia.org/show_bug.cgi?id=65847)
