### PR TITLE
Don't assume non-required global is set

### DIFF
--- a/DataValuesJavascript.php
+++ b/DataValuesJavascript.php
@@ -29,7 +29,7 @@ $GLOBALS['wgExtensionCredits']['datavalues'][] = array(
 
 // Resource Loader module registration
 $GLOBALS['wgResourceModules'] = array_merge(
-	$GLOBALS['wgResourceModules'],
+	isset( $GLOBALS['wgResourceModules'] ) ? $GLOBALS['wgResourceModules'] : array(),
 	include( __DIR__ . '/lib/resources.php' ),
 	include( __DIR__ . '/src/resources.php' )
 );


### PR DESCRIPTION
Why does this thing assume this variable is set? This makes my tests crash in my testing environment where I have error_reporting set to report everything.
