### PR TITLE
Updated UnDeserializableValue

### DIFF
--- a/DataValuesJavascript.php
+++ b/DataValuesJavascript.php
@@ -7,7 +7,7 @@ if ( defined( 'DATA_VALUES_JAVASCRIPT_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATA_VALUES_JAVASCRIPT_VERSION', '0.6.2-alpha' );
+define( 'DATA_VALUES_JAVASCRIPT_VERSION', '0.7.0-dev' );
 
 // Include the composer autoloader if it is present.
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ On [Packagist](https://packagist.org/packages/data-values/javascript):
 
 ## Release notes
 
-### 0.6.2 (dev)
+### 0.7.0 (dev)
+
+#### Breaking changes
+* Renamed `dataValues.UnUnserializableValue` to `dataValues.UnDeserializableValue`.
+* Changed constructor parameter order of `dataValues.UnDeserializableValue` (formerly `dataValues.UnUnserializableValue`).
 
 #### Enhancements
 * Consolidated code structure, updated and added code documentation to allow generating a proper documentation using JSDuck.

--- a/config.js
+++ b/config.js
@@ -114,7 +114,7 @@ this.config = ( function() {
 			'values/UnknownValue': [
 				'dataValues/dataValues', 'jquery', 'dataValues/DataValue', 'util/util.inherit'
 			],
-			'values/UnUnserializableValue': [
+			'values/UnDeserializableValue': [
 				'dataValues/dataValues', 'jquery', 'dataValues/DataValue', 'util/util.inherit'
 			],
 
@@ -201,7 +201,7 @@ this.config = ( function() {
 				'values/TimeValue',
 				'values/QuantityValue',
 				'values/UnknownValue',
-				'values/UnUnserializableValue'
+				'values/UnDeserializableValue'
 			],
 
 			// Shim test modules that external components depend on:
@@ -246,7 +246,7 @@ this.config = ( function() {
 			'tests/src/values/TimeValue.tests',
 			'tests/src/values/QuantityValue.tests',
 			'tests/src/values/UnknownValue.tests',
-			'tests/src/values/UnUnserializableValue.tests',
+			'tests/src/values/UnDeserializableValue.tests',
 
 			'tests/src/valueFormatters/valueFormatters.tests',
 			'tests/src/valueFormatters/ValueFormatterStore.tests',

--- a/src/resources.php
+++ b/src/resources.php
@@ -51,7 +51,7 @@ return call_user_func( function() {
 				'values/TimeValue.js',
 				'values/QuantityValue.js',
 				'values/UnknownValue.js',
-				'values/UnUnserializableValue.js',
+				'values/UnDeserializableValue.js',
 			),
 			'dependencies' => array(
 				'dataValues.DataValue',

--- a/src/values/UnDeserializableValue.js
+++ b/src/values/UnDeserializableValue.js
@@ -7,7 +7,7 @@ var PARENT = dv.DataValue;
  * Constructor for creating a data value representing a value which could not have been unserialized
  * for some reason. Holds the serialized value which can not be unserialized as well as an error
  * object describing the reason why the value can not be unserialized properly.
- * @class dataValues.UnUnserializableValue
+ * @class dataValues.UnDeserializableValue
  * @extends dataValues.DataValue
  * @since 0.1
  * @licence GNU GPL v2+
@@ -15,16 +15,16 @@ var PARENT = dv.DataValue;
  *
  * @constructor
  *
+ * @param {string} ofType The data value type the structure should have been unserialized to.
  * @param {Object} unUnserializableStructure Plain object assumingly representing some data value
  *        but the responsible unserializer was not able to unserialize it.
- * @param {string} ofType The data value type the structure should have been unserialized to.
  * @param {Error} unserializeError The error thrown during the attempt to unserialize the given
  *        structure.
  */
-var SELF = dv.UnUnserializableValue = util.inherit(
-	'DvUnUnserializableValue',
+var SELF = dv.UnDeserializableValue = util.inherit(
+	'DvUnDeserializableValue',
 	PARENT,
-	function( unUnserializableStructure, ofType, unserializeError ) {
+	function( ofType, unUnserializableStructure, unserializeError ) {
 		if( !$.isPlainObject( unUnserializableStructure ) ) {
 			throw new Error( 'The un-unserializable structure has to be a plain object' );
 		}
@@ -69,7 +69,7 @@ var SELF = dv.UnUnserializableValue = util.inherit(
 	/**
 	 * @inheritdoc
 	 *
-	 * @return {dataValues.UnUnserializableValue}
+	 * @return {dataValues.UnDeserializableValue}
 	 */
 	getValue: function() {
 		return this;

--- a/tests/src/values/UnDeserializableValue.tests.js
+++ b/tests/src/values/UnDeserializableValue.tests.js
@@ -7,7 +7,7 @@ define( [
 	'util/util.inherit',
 	'jquery',
 	'tests/src/dataValues.DataValue.tests',
-	'values/UnUnserializableValue'
+	'values/UnDeserializableValue'
 ], function( dv, util, $ ) {
 	'use strict';
 
@@ -20,13 +20,13 @@ define( [
 	 * @extends dv.tests.DataValueTest
 	 * @since 0.1
 	 */
-	dv.tests.UnUnserializableValueTest = util.inherit( PARENT, {
+	dv.tests.UnDeserializableValueTest = util.inherit( PARENT, {
 
 		/**
 		 * @inheritdoc
 		 */
 		getConstructor: function() {
-			return dv.UnUnserializableValue;
+			return dv.UnDeserializableValue;
 		},
 
 		/**
@@ -34,8 +34,8 @@ define( [
 		 */
 		getConstructorArguments: function() {
 			return [
-				[ {}, 'sometype', new Error( 'some error' ) ],
-				[ { foo: 'bar' }, 'another-type', new Error( 'another error' ) ]
+				[ 'sometype', {}, new Error( 'some error' ) ],
+				[ 'another-type', { foo: 'bar' }, new Error( 'another error' ) ]
 			];
 		},
 
@@ -96,8 +96,8 @@ define( [
 		testEquals: null
 	} );
 
-	var test = new dv.tests.UnUnserializableValueTest();
+	var test = new dv.tests.UnDeserializableValueTest();
 
-	test.runTests( 'dataValues.UnUnserializableValue' );
+	test.runTests( 'dataValues.UnDeserializableValue' );
 
 } );


### PR DESCRIPTION
- Common naming in `wikibase.serialization` was changed to `*Deserializer`.
- Applying the same parameter order as `dataValues.newDataValue`.