### PR TITLE
Do not pad year on the client

### DIFF
--- a/lib/time/time.Time.js
+++ b/lib/time/time.Time.js
@@ -361,7 +361,7 @@
 	};
 
 	function pad( number, digits ) {
-		number = '' + Math.abs( number );
+		number = String( Math.abs( number ) );
 
 		if ( number.length >= digits ) {
 			return number;

--- a/lib/time/time.Time.js
+++ b/lib/time/time.Time.js
@@ -363,7 +363,7 @@
 	function pad( number, digits ) {
 		number = '' + Math.abs( number );
 
-		if ( number.lenght >= digits ) {
+		if ( number.length >= digits ) {
 			return number;
 		}
 

--- a/lib/time/time.Time.js
+++ b/lib/time/time.Time.js
@@ -270,7 +270,7 @@
 		 */
 		iso8601: function() {
 			var g = this.gregorian();
-			return ( ( g.year < 0 ) ? '-' : '+' ) + pad( g.year, 11 ) + '-' + pad( g.month, 2 )
+			return ( g.year < 0 ? '' : '+' ) + g.year + '-' + pad( g.month, 2 )
 				+ '-' + pad( g.day, 2 ) + 'T' + pad( this._hour, 2 ) + ':' + pad( this._minute, 2 )
 				+ ':' + pad( this._second, 2 ) + 'Z';
 		},
@@ -361,7 +361,13 @@
 	};
 
 	function pad( number, digits ) {
-		return ( 1e12 + Math.abs( number ) + '' ).slice( -digits );
+		number = '' + Math.abs( number );
+
+		if ( number.lenght >= digits ) {
+			return number;
+		}
+
+		return new Array( digits - number.length + 1 ).join( '0' ) + number;
 	}
 
 	/**

--- a/tests/lib/time/time.Time.tests.js
+++ b/tests/lib/time/time.Time.tests.js
@@ -106,6 +106,31 @@ define( [
 		);
 	}
 
+	QUnit.test( 'time.Time.iso8601()', function( assert ) {
+		var definitions = {
+			'+1-00-00T00:00:00Z': {
+				calendarname: Time.CALENDAR.GREGORIAN,
+				year: 1,
+				precision: Time.PRECISION.YEAR
+			},
+			'+123456789012-00-00T00:00:00Z': {
+				calendarname: Time.CALENDAR.GREGORIAN,
+				year: 123456789012,
+				precision: Time.PRECISION.YEAR
+			}
+		};
+
+		$.each( definitions, function( expected, definition ) {
+			var actual = new Time( definition ).iso8601();
+
+			assert.ok(
+				expected === actual,
+				'Expected iso8601() to return "' + expected + '", got "' + actual + '"'
+			);
+
+		} );
+	} );
+
 	QUnit.test( 'time.Time.equals()', function( assert ) {
 		$.each( validTimeDefinitions, function( name, definition ) {
 			var time1 = new Time( definition ),


### PR DESCRIPTION
This removes the code that pads the year to exactly 11 digits. I do not consider this a breaking change but a bugfix for multiple reasons:

* Note how the pad function truncated (!) if the given number was longer than the requested number of digits.
* Note how the pad function was unable to correctly pad to more than 11 digits.
* Note how nothing of this was ever tested.
* Padding should, if required, be done in a single place on the server. The PHP parsers are able to understand ISO time strings with any (1 to 16) number of digits for the year.

Bug: [T66084](https://phabricator.wikimedia.org/T66084)