### PR TITLE
Do not crash UI for "unknown" calendar models

### DIFF
--- a/src/values/TimeValue.js
+++ b/src/values/TimeValue.js
@@ -98,12 +98,8 @@ SELF.newFromJSON = function( json ) {
 
 	// NOTE: Having the calendar model as url to Wikidata was a specified data model requirement.
 
-	// Time instance should be defined as Gregorian:
-	if( json.calendarmodel === 'http://www.wikidata.org/entity/Q1985727' ) {
-		finalTime = gregorianTime;
-	}
 	// Time instance should be defined as Julian:
-	else if( json.calendarmodel === 'http://www.wikidata.org/entity/Q1985786' ) {
+	if( /Q1985786$/i.test( json.calendarmodel ) ) {
 		// Since the data value saves the time as Gregorian, we first have to transform that back
 		// into Julian.
 		// NOTE: As of May 15 2013 we decided that this is nonsense and that we should always store
@@ -116,8 +112,9 @@ SELF.newFromJSON = function( json ) {
 			// todo: consider other fields, e.g. 'before', 'after' and 'utc'
 		);
 	}
+	// Time instance should be defined as Gregorian:
 	else {
-		throw new Error( 'Unknown calendar model "' + json.calendarmodel + '"' );
+		finalTime = gregorianTime;
 	}
 	return new SELF( finalTime );
 };


### PR DESCRIPTION
This patch does two things:

1. Lazy detection of the Julian calendar model. This will, for example, detect `http://www.wikidata.org/wiki/Q1985786` (note the word "wiki" instead of "entity") and do the right(tm) thing.
2. All other URLs are ignored and assumed to be Gregorian.

**This probably conflicts with #61 by @snaterlicious, but I wanted to store it so we don't forget.**

I can split this into two patches, if this helps in getting this merged faster.

Bug: [T89698](https://phabricator.wikimedia.org/T89698)