### PR TITLE
Fix typo in "JavaScript"

### DIFF
--- a/DataValuesJavascript.php
+++ b/DataValuesJavascript.php
@@ -16,7 +16,7 @@ if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 
 $GLOBALS['wgExtensionCredits']['datavalues'][] = array(
 	'path' => __DIR__,
-	'name' => 'DataValues Javascript',
+	'name' => 'DataValues JavaScript',
 	'version' => DATA_VALUES_JAVASCRIPT_VERSION,
 	'author' => array(
 		'[https://www.mediawiki.org/wiki/User:Danwe Daniel Werner]',

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DataValues Javascript
+# DataValues JavaScript
 
 This component is in alpha state and not suitable for reuse yet.
 It contains various JavaScript related to the DataValues library.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "data-values/javascript",
-	"description": "DataValues implementation in Javascript",
+	"description": "DataValues implementation in JavaScript",
 	"keywords": [
 		"datavalues",
 		"wikidata"


### PR DESCRIPTION
A thing called "Javascript" does not exist. This is the first of several small patches. This does not cause a breaking change, it's only fixing typos.