### PR TITLE
Fix inconsistency in MINUTES

### DIFF
--- a/src/values/TimeValue.js
+++ b/src/values/TimeValue.js
@@ -307,12 +307,12 @@ SELF.PRECISIONS = [
 	{ id: 'MONTH', text: 'month' },
 	{ id: 'DAY', text: 'day' },
 	{ id: 'HOUR', text: 'hour' },
-	{ id: 'MINUTES', text: 'minute' },
+	{ id: 'MINUTE', text: 'minute' },
 	{ id: 'SECOND', text: 'second' }
 ];
 
 /**
- * Retrieves a precision value by its ID.
+ * Retrieves a numeric precision value by its descriptive string id.
  * @static
  * @since 0.7
  *
@@ -320,11 +320,12 @@ SELF.PRECISIONS = [
  * @return {number|null}
  */
 SELF.getPrecisionById = function( id ) {
-	for( var i = 0; i < SELF.PRECISIONS.length; i++ ) {
+	for( var i = SELF.PRECISIONS.length - 1; i--; ) {
 		if( SELF.PRECISIONS[i].id === id ) {
-			return parseInt( i, 10 );
+			return i;
 		}
 	}
+
 	return null;
 };
 


### PR DESCRIPTION
* No other precision is plural.
* Removed the `parseInt` because the variable is already int.
* Reversed the loop. The idea is that the precisions relevant in production are usually at the high end of the array.

Bug: [T89243](https://phabricator.wikimedia.org/T89243)