### PR TITLE
Don't explicitly depend on jquery.qunit

### DIFF
--- a/DataValuesJavaScript.php
+++ b/DataValuesJavaScript.php
@@ -64,7 +64,6 @@ $GLOBALS['wgHooks']['ResourceLoaderTestModules'][] = function(
 			),
 			'dependencies' => array(
 				'dataValues.DataValue',
-				'jquery.qunit',
 				'util.inherit',
 				'valueFormatters',
 			),
@@ -76,7 +75,6 @@ $GLOBALS['wgHooks']['ResourceLoaderTestModules'][] = function(
 			),
 			'dependencies' => array(
 				'dataValues.DataValue',
-				'jquery.qunit',
 				'util.inherit',
 				'valueParsers',
 			),

--- a/lib/resources.php
+++ b/lib/resources.php
@@ -30,7 +30,6 @@ return call_user_func( function() {
 				'qunit.parameterize/qunit.parameterize.js',
 			),
 			'dependencies' => array(
-				'jquery.qunit',
 			),
 		),
 


### PR DESCRIPTION
Explicitly depending on jquery.qunit breaks qunit-karma-based test running, since qunit-karma loads its own QUnit instance. This closes [T94394](https://phabricator.wikimedia.org/T94394).