### PR TITLE
Make StringParser parse empty string as null

### DIFF
--- a/src/valueParsers/parsers/StringParser.js
+++ b/src/valueParsers/parsers/StringParser.js
@@ -20,7 +20,9 @@ vp.StringParser = util.inherit( PARENT, {
 	 * @param {string} rawValue
 	 */
 	parse: function( rawValue ) {
-		return $.Deferred().resolve( new dv.StringValue( rawValue ) ).promise();
+		return $.Deferred().resolve(
+			rawValue === '' ? null : new dv.StringValue( rawValue )
+		).promise();
 	}
 } );
 

--- a/tests/src/valueParsers/parsers/StringParser.tests.js
+++ b/tests/src/valueParsers/parsers/StringParser.tests.js
@@ -38,7 +38,8 @@ define( [
 				[ '42', new dv.StringValue( '42' ) ],
 				[ ' foo ', new dv.StringValue( ' foo ' ) ],
 				[ ' Baa', new dv.StringValue( ' Baa' ) ],
-				[ 'xXx ', new dv.StringValue( 'xXx ' ) ]
+				[ 'xXx ', new dv.StringValue( 'xXx ' ) ],
+				[ '', null ]
 			];
 		}
 


### PR DESCRIPTION
This patch changes the StringParser to return null when the given string
is empty.

Bug: T93572