### PR TITLE
Remove this references that refer to the window

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -27,20 +27,19 @@
 	// Environment
 	"browser": true,
 
-	// Globals
-	"predef": [
-		"dataValues",
-		"globeCoordinate",
-		"jQuery",
-		"mediaWiki",
-		"QUnit",
-		"valueFormatters",
-		"valueParsers",
-		"time",
-		"util",
-		// require.js globals:
-		"require",
-		"requirejs",
-		"define"
-	]
+	"globals": {
+		"define": false,
+		"jQuery": false,
+		"mediaWiki": false,
+		"QUnit": false,
+		"require": false,
+		"requirejs": false,
+		"time": false,
+
+		"dataValues": true,
+		"globeCoordinate": true,
+		"util": true,
+		"valueFormatters": true,
+		"valueParsers": true
+	}
 }

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >
  */
-this.config = ( function() {
+config = ( function() {
 	'use strict';
 
 	return {

--- a/lib/globeCoordinate/globeCoordinate.js
+++ b/lib/globeCoordinate/globeCoordinate.js
@@ -8,7 +8,7 @@
  * @author Denny Vrandečić
  * @author H. Snater < mediawiki@snater.com >
  */
-this.globeCoordinate = ( function() {
+globeCoordinate = ( function() {
 	'use strict';
 
 	return {

--- a/lib/util/util.inherit.js
+++ b/lib/util/util.inherit.js
@@ -2,7 +2,7 @@
  * @class util
  * @singleton
  */
-this.util = this.util || {};
+util = util || {};
 
 ( function( util ) {
 	'use strict';

--- a/src/dataValues.js
+++ b/src/dataValues.js
@@ -6,7 +6,7 @@
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-this.dataValues = new ( function Dv() {
+dataValues = new ( function Dv() {
 	'use strict';
 
 	var dvs = [];

--- a/src/valueFormatters/valueFormatters.js
+++ b/src/valueFormatters/valueFormatters.js
@@ -1,4 +1,4 @@
 /**
  * @ignore
  */
-this.valueFormatters = this.valueFormatters || {};
+valueFormatters = valueFormatters || {};

--- a/src/valueParsers/valueParsers.js
+++ b/src/valueParsers/valueParsers.js
@@ -1,4 +1,4 @@
 /**
  * @ignore
  */
-this.valueParsers = this.valueParsers || {};
+valueParsers = valueParsers || {};


### PR DESCRIPTION
To what does `this` refer to? It's obviously meant to refer to the global scope, which usually is `window`. My PHPStorm complains about the `this` referring to nothing. It should just work fine without this.