### PR TITLE
Properly document globe precision null

### DIFF
--- a/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
+++ b/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
@@ -12,7 +12,7 @@
 	 * @param {Object} gcDef Needs the following attributes:
 	 *        - {number} latitude
 	 *        - {number} longitude
-	 *        - {number} precision
+	 *        - {number|null} precision
 	 *
 	 * @throws {Error} when latitude is greater than 360.
 	 * @throws {Error} when longitude is greater than 360.
@@ -70,7 +70,7 @@
 
 		/**
 		 * Precision
-		 * @property {number}
+		 * @property {number|null}
 		 * @private
 		 */
 		_precision: null,
@@ -101,7 +101,7 @@
 		/**
 		 * Returns the precision.
 		 *
-		 * @return {number}
+		 * @return {number|null}
 		 */
 		getPrecision: function() { return this._precision; },
 


### PR DESCRIPTION
This **can be** and actually **is** allowed to be null in our internal JSON serialization as well as in the PHP DataModel.