### PR TITLE
GlobeCoordinate: support other globes

### DIFF
--- a/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
+++ b/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
@@ -40,7 +40,7 @@
 			throw new Error( 'Longitude (' + this._longitude + ') is out of bounds' );
 		}
 
-		this._globe = 'http://www.wikidata.org/entity/Q2'; // TODO: Support other globes
+		this._globe = gcDef.globe || 'http://www.wikidata.org/entity/Q2';
 	};
 
 	SELF.prototype = {
@@ -144,7 +144,8 @@
 				gc2Iso6709 = globeCoordinate.iso6709( otherGlobeCoordinate.getDecimal() );
 
 			return Math.abs( this.getPrecision() - otherGlobeCoordinate.getPrecision() ) < 0.00000001
-				&& gc1Iso6709 === gc2Iso6709;
+				&& gc1Iso6709 === gc2Iso6709
+				&& this.getGlobe() === otherGlobeCoordinate.getGlobe();
 		}
 	};
 

--- a/tests/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.tests.js
+++ b/tests/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.tests.js
@@ -14,7 +14,7 @@ define( [
 	QUnit.module( 'globeCoordinate.GlobeCoordinate.js' );
 
 	QUnit.test( 'Basic checks', function( assert ) {
-		assert.expect( 12 );
+		assert.expect( 14 );
 		var c;
 
 		assert.throws(
@@ -59,6 +59,12 @@ define( [
 			'Verified getPrecision()'
 		);
 
+		assert.equal(
+			c.getGlobe(),
+			'http://www.wikidata.org/entity/Q2',
+			'Verified getGlobe()'
+		);
+
 		assert.deepEqual(
 			c.getDecimal(),
 			{ latitude: 1.5, longitude: 1.5, precision: 0.1 },
@@ -92,10 +98,23 @@ define( [
 			'Verified precision is null'
 		);
 
+		// test with custom globe
+		c = new globeCoordinate.GlobeCoordinate( {
+			latitude: 20,
+			longitude: 25.5,
+			globe: 'http://www.wikidata.org/entity/Q313'
+		} );
+
+		assert.equal(
+			c.getGlobe(),
+			'http://www.wikidata.org/entity/Q313',
+			'Verified getGlobe()'
+		);
+
 	} );
 
 	QUnit.test( 'Strict (in)equality', function( assert ) {
-		assert.expect( 121 );
+		assert.expect( 169 );
 		var gcDefs = [
 				{ latitude: 0, longitude: 0, precision: 1 },
 				{ latitude: -3, longitude: 2, precision: 1 },
@@ -107,7 +126,9 @@ define( [
 				{ latitude: 1.00028, longitude: 0, precision: 1 / 3600 },
 				{ latitude: 1.0005, longitude: 0, precision: 1 / 36000 },
 				{ latitude: 89.9, longitude: -0.00031, precision: 1 / 3600000 },
-				{ latitude: 5, longitude: -0.00292, precision: 1 / 36000 }
+				{ latitude: 5, longitude: -0.00292, precision: 1 / 36000 },
+				{ latitude: 5, longitude: 2, precision: 1, globe: 'http://www.wikidata.org/entity/Q2' },
+				{ latitude: 5, longitude: 2, precision: 1, globe: 'http://www.wikidata.org/entity/Q313' }
 			],
 			c1, c2;
 
@@ -120,6 +141,8 @@ define( [
 				if( gcDef1.latitude === gcDef2.latitude
 					&& gcDef1.longitude === gcDef2.longitude
 					&& gcDef1.precision === gcDef2.precision
+					&& ( gcDef1.globe || 'http://www.wikidata.org/entity/Q2' ) ===
+						( gcDef2.globe || 'http://www.wikidata.org/entity/Q2' )
 				) {
 					assert.ok(
 						c1.equals( c2 ),


### PR DESCRIPTION
Prefer the injected value instead of the hard-coded 'http://www.wikidata.org/entity/Q2'.

Add tests.

Bug: [T105321](//phabricator.wikimedia.org/T105321)