### PR TITLE
Add support for precision null to GlobeCoordinate

### DIFF
--- a/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
+++ b/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
@@ -12,7 +12,7 @@
 	 * @param {Object} gcDef Needs the following attributes:
 	 *        - {number} latitude
 	 *        - {number} longitude
-	 *        - {number} precision
+	 *        - {number|null} [precision]
 	 *
 	 * @throws {Error} when latitude is greater than 360.
 	 * @throws {Error} when longitude is greater than 360.
@@ -27,7 +27,7 @@
 
 		this._latitude = gcDef.latitude;
 		this._longitude = gcDef.longitude;
-		this._precision = gcDef.precision;
+		this._precision = gcDef.precision || null;
 
 		// TODO: Capture altitude and globe
 
@@ -70,7 +70,7 @@
 
 		/**
 		 * Precision
-		 * @property {number}
+		 * @property {number|null}
 		 * @private
 		 */
 		_precision: null,
@@ -101,7 +101,7 @@
 		/**
 		 * Returns the precision.
 		 *
-		 * @return {number}
+		 * @return {number|null}
 		 */
 		getPrecision: function() { return this._precision; },
 
@@ -143,7 +143,8 @@
 			var gc1Iso6709 = globeCoordinate.iso6709( this.getDecimal() ),
 				gc2Iso6709 = globeCoordinate.iso6709( otherGlobeCoordinate.getDecimal() );
 
-			return Math.abs( this._precision - otherGlobeCoordinate._precision ) < 0.00000001
+			return ( this._precision === otherGlobeCoordinate._precision
+				|| Math.abs( this._precision - otherGlobeCoordinate._precision ) < 0.00000001 )
 				&& gc1Iso6709 === gc2Iso6709
 				&& this._globe === otherGlobeCoordinate._globe;
 		}

--- a/tests/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.tests.js
+++ b/tests/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.tests.js
@@ -14,7 +14,7 @@ define( [
 	QUnit.module( 'globeCoordinate.GlobeCoordinate.js' );
 
 	QUnit.test( 'Basic checks', function( assert ) {
-		assert.expect( 13 );
+		assert.expect( 10 );
 		var c;
 
 		assert.throws(
@@ -76,26 +76,26 @@ define( [
 			'string',
 			'Verified iso6709()'
 		);
+	} );
 
-		// test with no precision provided
-		c = new globeCoordinate.GlobeCoordinate( { latitude: 20, longitude: 25.5 } );
+	QUnit.test( 'Precision defaults to null', function( assert ) {
+		assert.expect( 3 );
+		var c = new globeCoordinate.GlobeCoordinate( { latitude: 0, longitude: 0 } );
 
-		assert.equal(
-			c.getLatitude(),
-			20,
-			'Verified getLatitude()'
+		assert.ok(
+			c.getPrecision() === null,
+			'Verified getPrecision()'
 		);
 
-		assert.equal(
-			c.getLongitude(),
-			25.5,
-			'Verified getLatitude()'
+		assert.deepEqual(
+			c.getDecimal(),
+			{ latitude: 0, longitude: 0, precision: null },
+			'Verified getDecimal()'
 		);
 
-		assert.equal(
-			c.getPrecision(),
-			null,
-			'Verified precision is null'
+		assert.ok(
+			c.equals( c ),
+			'Validated equality'
 		);
 	} );
 
@@ -117,6 +117,36 @@ define( [
 			typeof c.getDecimal().globe === 'undefined',
 			'Verified getDecimal()'
 		);
+	} );
+
+	QUnit.test( 'ISO 6709 strings', function( assert ) {
+		assert.expect( 12 );
+		var gcDefs = [
+				{ precision: 10, expected: '+10+010/' },
+				{ precision: 2, expected: '+14+012/' },
+				{ precision: 1, expected: '+13+012/' },
+				{ precision: 0.1, expected: '+1307+01207/' },
+				{ precision: 0.01, expected: '+130724+0120724/' },
+				{ precision: 1 / 60, expected: '+1307+01207/' },
+				{ precision: 1 / 3600, expected: '+130724+0120724/' },
+				{ precision: 1 / 36000, expected: '+130724.4+0120724.4/' },
+				{ precision: 1 / 360000, expected: '+130724.42+0120724.42/' },
+				{ precision: 0, expected: '+130724.42+0120724.42/' },
+				{ precision: null, expected: '+130724.42+0120724.42/' },
+				{ expected: '+130724.42+0120724.42/' }
+			],
+			c;
+
+		$.each( gcDefs, function( i, gcDef ) {
+			c = new globeCoordinate.GlobeCoordinate(
+				{ latitude: 13.12345, longitude: 12.12345, precision: gcDef.precision }
+			);
+
+			assert.ok(
+				c.iso6709() === gcDef.expected,
+				'Validated ISO 6709 string of data set #' + i + '.'
+			);
+		} );
 	} );
 
 	QUnit.test( 'Strict (in)equality', function( assert ) {


### PR DESCRIPTION
Before #53 the implementation already supported both null and undefined precisions, but this was never tested properly, only slightly with a lazy `assert.equal( …, null )` that accepts `undefined` as `null`. #53 broke this feature, but not the test, because it was never calling `equals` with an undefined precision.

The backend also supports precision null, see https://github.com/DataValues/Geo/blob/master/src/Values/GlobeCoordinateValue.php.