### PR TITLE
Split very complex GlobeCoordinate test

### DIFF
--- a/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
+++ b/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.js
@@ -143,9 +143,9 @@
 			var gc1Iso6709 = globeCoordinate.iso6709( this.getDecimal() ),
 				gc2Iso6709 = globeCoordinate.iso6709( otherGlobeCoordinate.getDecimal() );
 
-			return Math.abs( this.getPrecision() - otherGlobeCoordinate.getPrecision() ) < 0.00000001
+			return Math.abs( this._precision - otherGlobeCoordinate._precision ) < 0.00000001
 				&& gc1Iso6709 === gc2Iso6709
-				&& this.getGlobe() === otherGlobeCoordinate.getGlobe();
+				&& this._globe === otherGlobeCoordinate._globe;
 		}
 	};
 

--- a/tests/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.tests.js
+++ b/tests/lib/globeCoordinate/globeCoordinate.GlobeCoordinate.tests.js
@@ -14,7 +14,7 @@ define( [
 	QUnit.module( 'globeCoordinate.GlobeCoordinate.js' );
 
 	QUnit.test( 'Basic checks', function( assert ) {
-		assert.expect( 14 );
+		assert.expect( 13 );
 		var c;
 
 		assert.throws(
@@ -97,9 +97,11 @@ define( [
 			null,
 			'Verified precision is null'
 		);
+	} );
 
-		// test with custom globe
-		c = new globeCoordinate.GlobeCoordinate( {
+	QUnit.test( 'Costum globe', function( assert ) {
+		assert.expect( 2 );
+		var c = new globeCoordinate.GlobeCoordinate( {
 			latitude: 20,
 			longitude: 25.5,
 			globe: 'http://www.wikidata.org/entity/Q313'
@@ -111,6 +113,10 @@ define( [
 			'Verified getGlobe()'
 		);
 
+		assert.ok(
+			typeof c.getDecimal().globe === 'undefined',
+			'Verified getDecimal()'
+		);
 	} );
 
 	QUnit.test( 'Strict (in)equality', function( assert ) {


### PR DESCRIPTION
* Split big "Basic checks" test.
* Add test that `getDecimal` does **not** contain the globe.
* Avoid calling getters when not necessary.