### PR TITLE
Add missing break to globeCoordinate.Formatter

### DIFF
--- a/lib/globeCoordinate/globeCoordinate.Formatter.js
+++ b/lib/globeCoordinate/globeCoordinate.Formatter.js
@@ -16,7 +16,8 @@
 			{ precision: 1 / 3600, text: 'to an arcsecond' },
 			{ precision: 1 / 36000, text: 'to 1/10 of an arcsecond' },
 			{ precision: 1 / 360000, text: 'to 1/100 of an arcsecond' },
-			{ precision: 1 / 3600000, text: 'to 1/1000 of an arcsecond' }
+			{ precision: 1 / 3600000, text: 'to 1/1000 of an arcsecond' },
+			{ precision: 1 / 36000000, text: '1/10000\'' }
 		],
 		format: 'decimal'
 	};
@@ -152,8 +153,9 @@
 		// Figure out if the precision is very close to a precision that can be expressed with a
 		// string:
 		for( var i in combinedOptions.precisionTexts ) {
-			if( Math.abs( precision - combinedOptions.precisionTexts[i].precision ) < 0.0000001 ) {
+			if ( Math.abs( precision - combinedOptions.precisionTexts[i].precision ) < 0.000000000001 ) {
 				precisionText = combinedOptions.precisionTexts[i].text;
+				break;
 			}
 		}
 


### PR DESCRIPTION
* The main issue here is the missing `break`.
* 1 / 36000000 is not an option you can select in the UI, but is something that can be detected by the backend. At the moment this is shown as "special (±2.7777777777778e-8°)". With this addition this is shown as "special (1/10000')"
* The epsilon must be lowered together with the smallest predefined precision. I'm using the maximum number of zeros that a coordinate value of 360.000000000000… can have before IEEE makes it start becoming fuzzy (this is around 15 significant digits). Try `( 360.1 ).toFixed( 20 )` in the JavaScript console to see what I mean.