### PR TITLE
Add PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,17 @@
 	"require": {
 		"composer/installers": ">=1.0.1"
 	},
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "~0.5"
+	},
 	"autoload": {
 		"files" : [
 			"DataValuesJavaScript.php"
+		]
+	},
+	"scripts": {
+		"phpcs": [
+			"vendor/bin/phpcs src/* --standard=phpcs.xml -sp"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="DataValuesJavaScript">
+	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
+	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+	</rule>
+
+	<arg name="extensions" value="php" />
+</ruleset>


### PR DESCRIPTION
This is the most minimal patch I can think of to add PHPCS support to this component. I'm reusing the predefined MediaWiki rule set with no additional rules (for now).