### PR TITLE
Minor fixups to JSDoc comments

### DIFF
--- a/src/values/MonolingualTextValue.js
+++ b/src/values/MonolingualTextValue.js
@@ -15,8 +15,8 @@ var PARENT = dv.DataValue;
  *
  * @constructor
  *
- * @param {String} languageCode
- * @param {String} value
+ * @param {string} languageCode
+ * @param {string} text
  */
 var SELF
 	= dv.MonolingualTextValue

--- a/src/values/NumberValue.js
+++ b/src/values/NumberValue.js
@@ -13,7 +13,7 @@ var PARENT = dv.DataValue;
  *
  * @constructor
  *
- * @param {Number} value
+ * @param {number} value
  */
 var SELF = dv.NumberValue = util.inherit( 'DvNumberValue', PARENT, function( value ) {
 	// TODO: validate

--- a/tests/src/dataValues.DataValue.tests.js
+++ b/tests/src/dataValues.DataValue.tests.js
@@ -81,7 +81,7 @@ define( [
 		 *
 		 * @since 0.1
 		 *
-		 * @param {String} moduleName
+		 * @param {string} moduleName
 		 */
 		runTests: function( moduleName ) {
 			QUnit.module( moduleName );
@@ -272,8 +272,8 @@ define( [
 	 *
 	 * @since 0.1
 	 *
-	 * @param {Number} argNumber
-	 * @param {String} functionName
+	 * @param {number} argNumber
+	 * @param {string} functionName
 	 *
 	 * @return {Function}
 	 */

--- a/tests/src/valueParsers/valueParsers.tests.js
+++ b/tests/src/valueParsers/valueParsers.tests.js
@@ -67,7 +67,7 @@
 		 *
 		 * @since 0.1
 		 *
-		 * @param {String} moduleName
+		 * @param {string} moduleName
 		 */
 		runTests: function( moduleName ) {
 			QUnit.module( moduleName );


### PR DESCRIPTION
Upper case means it must be an object, but these are not required to be objects.