### PR TITLE
Remove composer/installers dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.5.9",
-		"composer/installers": ">=1.0.1"
+		"php": ">=5.5.9"
 	},
 	"require-dev": {
 		"wikibase/wikibase-codesniffer": "^0.1.0"


### PR DESCRIPTION
This was introduced with 75343a823dc625bbc2966490b3d5001988837108 by @JeroenDeDauw. I tried to understand why, but can't figure it out. The component consists of nothing but a series of `…Installer` classes, including [a `MediaWikiInstaller` one](https://github.com/composer/installers/blob/master/src/Composer/Installers/MediaWikiInstaller.php). I can't find usages of these classes, neither today not back then when the dependency was introduced.

Either this was added by mistake, or (more likely) I'm missing something. @JeroenDeDauw, can you please have a look?