### PR TITLE
Restore TimeValue.getYear still used by ValueView

### DIFF
--- a/DataValuesJavaScript.php
+++ b/DataValuesJavaScript.php
@@ -7,7 +7,7 @@ if ( defined( 'DATA_VALUES_JAVASCRIPT_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATA_VALUES_JAVASCRIPT_VERSION', '0.8.4' );
+define( 'DATA_VALUES_JAVASCRIPT_VERSION', '0.9.0' );
 
 // Include the composer autoloader if it is present.
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ On [Packagist](https://packagist.org/packages/data-values/javascript):
 
 ## Release notes
 
+### 0.9.0 (dev)
+* Deprecated `dataValues.TimeValue.getYear`.
+* Removed `dataValues.TimeValue.getMonth`, `getDay`, `getHour`, `getMinute`, and `getSecond`.
+* Made `globeCoordinate.GlobeCoordinate.getDecimal` private.
+
 ### 0.8.4 (2017-07-18)
 * Updated JSDoc tags mistakenly requiring objects.
 * Removed an unused dependency on `composer/installers`.

--- a/src/values/TimeValue.js
+++ b/src/values/TimeValue.js
@@ -151,6 +151,16 @@ var SELF = dv.TimeValue = util.inherit( 'DvTimeValue', PARENT, function( timesta
 	},
 
 	/**
+	 * @since 0.7
+	 * @deprecated since 0.9
+	 *
+	 * @return {string}
+	 */
+	getYear: function() {
+		return /^[+-]\d+/.exec( this.timestamp )[0];
+	},
+
+	/**
 	 * @inheritdoc
 	 */
 	equals: function( value ) {


### PR DESCRIPTION
I removed this in #116, but I was wrong about the usage. This method is still used in a single place in the ValueView component on a line that was previously not type hinted at all: https://phabricator.wikimedia.org/diffusion/GDVV/browse/master/src/ExpertExtender/ExpertExtender.CalendarHint.js;6c328d1a0e5014313c2b11b1691b75e0a2d1b5c2$98

My goal still is to remove said code in the ValueView component, but for the moment it's easier to temporarily restore the method here.