### PR TITLE
Remove now unused TimeValue.getYear

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ On [Packagist](https://packagist.org/packages/data-values/javascript):
 ## Release notes
 
 ### 0.9.0 (dev)
-* Deprecated `dataValues.TimeValue.getYear`.
-* Removed `dataValues.TimeValue.getMonth`, `getDay`, `getHour`, `getMinute`, and `getSecond`.
-* Made `globeCoordinate.GlobeCoordinate.getDecimal` private.
+* Removed `dataValues.TimeValue.getYear`, `getMonth`, `getDay`, `getHour`, `getMinute`, and
+  `getSecond`.
+* Declared `globeCoordinate.GlobeCoordinate.getDecimal` private.
 
 ### 0.8.4 (2017-07-18)
 * Updated JSDoc tags mistakenly requiring objects.

--- a/src/values/TimeValue.js
+++ b/src/values/TimeValue.js
@@ -151,16 +151,6 @@ var SELF = dv.TimeValue = util.inherit( 'DvTimeValue', PARENT, function( timesta
 	},
 
 	/**
-	 * @since 0.7
-	 * @deprecated since 0.9
-	 *
-	 * @return {string}
-	 */
-	getYear: function() {
-		return /^[+-]\d+/.exec( this.timestamp )[0];
-	},
-
-	/**
 	 * @inheritdoc
 	 */
 	equals: function( value ) {


### PR DESCRIPTION
This reverts #118 now that the last usage is gone via https://gerrit.wikimedia.org/r/370835.

[Bug: T172916](https://phabricator.wikimedia.org/T172916)