### PR TITLE
Add missing class level documentation links

### DIFF
--- a/src/DataValue.js
+++ b/src/DataValue.js
@@ -28,6 +28,9 @@ var SELF = dv.DataValue = function DvDataValue() {
  */
 SELF.TYPE = null;
 
+/**
+ * @class dataValues.DataValue
+ */
 $.extend( SELF.prototype, {
 
 	/**

--- a/src/valueFormatters/formatters/ValueFormatter.js
+++ b/src/valueFormatters/formatters/ValueFormatter.js
@@ -17,6 +17,9 @@ var SELF = vf.ValueFormatter = function VpValueFormatter( options ) {
 	this._options = $.extend( {}, options || {} );
 };
 
+/**
+ * @class valueFormatters.ValueFormatter
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * Formatter options.

--- a/src/valueParsers/ValueParserStore.js
+++ b/src/valueParsers/ValueParserStore.js
@@ -32,6 +32,9 @@ var SELF = vp.ValueParserStore = function VpValueParserStore( DefaultParser ) {
 	this._parsersForDataValueTypes = {};
 };
 
+/**
+ * @class valueParsers.ValueParserStore
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * Default parser constructor to be returned when no parser is registered for a specific

--- a/src/valueParsers/parsers/ValueParser.js
+++ b/src/valueParsers/parsers/ValueParser.js
@@ -17,6 +17,9 @@ var SELF = vp.ValueParser = function VpValueParser( options ) {
 	this._options = $.extend( {}, options || {} );
 };
 
+/**
+ * @class valueParsers.ValueParser
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * Parser options.


### PR DESCRIPTION
This does make the documentation much stronger. Without this, an IDE has a hard time figuring out that the `$.extends` stuff belongs to the class constructor directly above. With this, my IDE finally understands which properties and methods belong to these classes.


If you merge this, please also merge https://github.com/wmde/WikibaseDataModelJavaScript/pull/75.