### PR TITLE
Use Daniel Werners preferred email address

### DIFF
--- a/lib/util/util.inherit.js
+++ b/lib/util/util.inherit.js
@@ -41,7 +41,7 @@ this.util = this.util || {};
 	/**
 	 * Helper for prototypical inheritance.
 	 * @license GPL-2.0+
-	 * @author Daniel Werner < daniel.werner@wikimedia.de >
+	 * @author Daniel Werner < daniel.a.r.werner@gmail.com >
 	 *
 	 * @param {string|Function} [nameOrBase] The name of the new constructor (currently not used).
 	 *        This is handy for debugging purposes since instances of the constructor might be

--- a/src/valueParsers/parsers/StringParser.js
+++ b/src/valueParsers/parsers/StringParser.js
@@ -9,7 +9,7 @@ var PARENT = vp.ValueParser;
  * @extends valueParsers.ValueParser
  * @since 0.1
  * @license GPL-2.0+
- * @author Daniel Werner < danweetz@web.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  */

--- a/src/values/MonolingualTextValue.js
+++ b/src/values/MonolingualTextValue.js
@@ -10,7 +10,7 @@ var PARENT = dv.DataValue;
  * @extends dataValues.DataValue
  * @since 0.1
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  *
  * @constructor

--- a/src/values/MultilingualTextValue.js
+++ b/src/values/MultilingualTextValue.js
@@ -11,7 +11,7 @@ var PARENT = dv.DataValue;
  * @since 0.1
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  *

--- a/src/values/NumberValue.js
+++ b/src/values/NumberValue.js
@@ -9,7 +9,7 @@ var PARENT = dv.DataValue;
  * @extends dataValues.DataValue
  * @since 0.1
  * @license GPL-2.0+
- * @author Daniel Werner < danweetz@web.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  *

--- a/src/values/UnDeserializableValue.js
+++ b/src/values/UnDeserializableValue.js
@@ -11,7 +11,7 @@ var PARENT = dv.DataValue;
  * @extends dataValues.DataValue
  * @since 0.1
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  *

--- a/tests/src/valueParsers/parsers/FloatParser.tests.js
+++ b/tests/src/valueParsers/parsers/FloatParser.tests.js
@@ -1,6 +1,6 @@
 /**
  * @license GPL-2.0+
- * @author Daniel Werner < danweetz@web.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  */
 ( function( vp, dv, util ) {
 	'use strict';

--- a/tests/src/valueParsers/parsers/StringParser.tests.js
+++ b/tests/src/valueParsers/parsers/StringParser.tests.js
@@ -1,6 +1,6 @@
 /**
  * @license GPL-2.0+
- * @author Daniel Werner < danweetz@web.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  */
 ( function( vp, dv, util ) {
 	'use strict';

--- a/tests/src/valueParsers/valueParsers.tests.js
+++ b/tests/src/valueParsers/valueParsers.tests.js
@@ -1,7 +1,7 @@
 /**
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Daniel Werner < danweetz@web.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  */
 ( function( vp, dv, util, $, QUnit ) {
 	'use strict';

--- a/tests/src/values/NumberValue.tests.js
+++ b/tests/src/values/NumberValue.tests.js
@@ -1,6 +1,6 @@
 /**
  * @license GPL-2.0+
- * @author Daniel Werner < danweetz@web.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  */
 ( function( dv, util ) {
 	'use strict';

--- a/tests/src/values/TimeValue.tests.js
+++ b/tests/src/values/TimeValue.tests.js
@@ -1,6 +1,6 @@
 /**
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  */
 ( function( dv, util ) {
 	'use strict';

--- a/tests/src/values/UnDeserializableValue.tests.js
+++ b/tests/src/values/UnDeserializableValue.tests.js
@@ -1,6 +1,6 @@
 /**
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  */
 ( function( dv, util, $ ) {
 	'use strict';


### PR DESCRIPTION
I contacted Daniel Werner and asked him which email address he prefers.

I had two reasons to touch this:
* Daniels wikimedia.de email does not exist any more.
* He used so many different @author tags and I wanted to unify them.